### PR TITLE
set bug fix for unplayed sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ smash = pysmash.SmashGG()
   print(events)
 
   # Shows a complete list of sets given tournament and event names
+  # This method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
+  # potentially fed into another bracket.)
   sets = smash.tournament_show_sets('hidden-bosses-4-0', 'wii-u-singles')
   print(sets) # note: result might be VERY large for larger tournaments.
 
@@ -82,10 +84,14 @@ smash = pysmash.SmashGG()
   print(brackets)
 
   # Shows player info and a list of every set that player competed in given tournament and event names
+  # This method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
+  # potentially fed into another bracket.)
   player_sets = smash.tournament_show_player_sets('hidden-bosses-4-0', 'DOM', 'wii-u-singles')
   print(player_sets)
 
   #Show sets between two players for a given tournament and event names
+  # This method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
+  # potentially fed into another bracket.)
   player_head_to_head = smash.tournament_show_head_to_head('hidden-bosses-4-0', 'giant', 'hamada', 'wii-u-singles')
   print(player_head_to_head)
 
@@ -115,6 +121,8 @@ import pysmash
   print(bracket_players)
 
   # show played sets for a bracket
+  # This method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
+  # potentially fed into another bracket.)
   brackets = smash.tournament_show_event_brackets('hidden-bosses-4-0', 'wii-u-singles')
   sets =  self.smash.bracket_show_sets(brackets['bracket_ids'][0]) # <- bracket_id
   # sets = self.smash.bracket_show_sets(225024) # <- if you know the id before hand
@@ -254,6 +262,9 @@ so I encourage you to run tests individually and not very often.
   ...
 ]
 ```
+
+**Notes:**
+- This method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set fed into another bracket.)
 
 **Method Signature:**
 `tournament_show_head_to_head('hidden-bosses-4-0', 'giant', 'hamada', 'wii-u-singles')`

--- a/pysmash/brackets.py
+++ b/pysmash/brackets.py
@@ -119,6 +119,12 @@ def _filter_set_response(response):
         if 'preview' in str((bracket_set['id'])):
             break
 
+        winner_score = bracket_set.get('entrant1Score', None)
+        loser_score = bracket_set.get('entrant2Score', None)
+
+        if winner_score is None or loser_score is None:
+            continue
+
         _set = _get_set_from_bracket(bracket_set, is_final_bracket)
         results_sets.append(_set)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(name="pysmash",
       author="Peter Wensel",
       url="https://github.com/PeterCat12/pysmash",
       description="python bindings for Smash.gg API",
-      version="2.1.0",
+      version="2.1.1",
       packages=[
           'pysmash',
       ],

--- a/tests.py
+++ b/tests.py
@@ -78,11 +78,11 @@ class TournamentMethods(BaseTestClass):
 
     def test_tournament_show_sets(self):
         result = self.smash.tournament_show_sets('hidden-bosses-4-0', 'wii-u-singles')
-        self.assertTrue(len(result) == 423)
+        self.assertTrue(len(result) == 312)
 
         self.smash.set_default_event('wii-u-singles')
         result = self.smash.tournament_show_sets('hidden-bosses-4-0')
-        self.assertTrue(len(result) == 423)
+        self.assertTrue(len(result) == 312)
 
     def test_tournamaent_show_sets_other_events(self):
         result = self.smash.tournament_show_sets(tournament_name='kombat-cup-week-4',
@@ -90,7 +90,7 @@ class TournamentMethods(BaseTestClass):
         self.assertTrue(len(result) == 255)
         result = self.smash.tournament_show_sets(tournament_name='hidden-bosses-4-0',
                                                  event='wii-u-doubles')
-        self.assertTrue(len(result) == 95)
+        self.assertTrue(len(result) == 76)
 
     def test_tournament_show_players(self):
         with self.assertRaises(ValidationError) as context:
@@ -155,7 +155,7 @@ class TournamentMethods(BaseTestClass):
 
     def test_bracket_show_sets(self):
         result = self.smash.bracket_show_sets(225024)
-        self.assertTrue(len(result) == 47)
+        self.assertTrue(len(result) == 46)
 
     def test_tournament_show_events(self):
         result = self.smash.tournament_show_events('hidden-bosses-4-0')
@@ -185,7 +185,6 @@ class TournamentMethods(BaseTestClass):
     def test_tournament_show_head_to_head(self):
         results = self.smash.tournament_show_head_to_head('hidden-bosses-4-0', 'giant', 'hamada',
                                                           'wii-u-singles')
-        print(results)
         self.assertTrue(len(results['sets']) == 1)
         self.assertTrue(results['sets'][0]['opponent_info']['tag'].lower() == 'hamada')
 


### PR DESCRIPTION
unplayed sets were being returned in the set methods. Either the sets
were not played (there was a “by” round, or the set fed into another
bracket). No idea why SmashGG returns those sets.