### PR TITLE
fix bug where player sets would return correct results but tournament…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(name="pysmash",
       author="Peter Wensel",
       url="https://github.com/PeterCat12/pysmash",
       description="python bindings for Smash.gg API",
-      version="2.1.2",
+      version="2.1.3",
       packages=[
           'pysmash',
       ],

--- a/tests.py
+++ b/tests.py
@@ -78,19 +78,30 @@ class TournamentMethods(BaseTestClass):
 
     def test_tournament_show_sets(self):
         result = self.smash.tournament_show_sets('hidden-bosses-4-0', 'wii-u-singles')
-        self.assertTrue(len(result) == 312)
+        self.assertTrue(len(result) == 244)
+
+        # test that Dom only played 6 matches
+        count = 0
+        for _set in result:
+            if _set['entrant_1_id'] == '321247' or _set['entrant_2_id'] == '321247':
+                count = count + 1
+        self.assertTrue(count, 6)
+
+        result = self.smash.tournament_show_player_sets('hidden-bosses-4-0', 'DOM', 'wii-u-singles')
+        self.assertTrue(len(result['sets']), 6)
+        self.assertTrue(len(result['sets']), count)
 
         self.smash.set_default_event('wii-u-singles')
         result = self.smash.tournament_show_sets('hidden-bosses-4-0')
-        self.assertTrue(len(result) == 312)
+        self.assertTrue(len(result) == 244)
 
     def test_tournamaent_show_sets_other_events(self):
         result = self.smash.tournament_show_sets(tournament_name='kombat-cup-week-4',
                                                  event='mkxl')
-        self.assertTrue(len(result) == 255)
+        self.assertTrue(len(result) == 212)
         result = self.smash.tournament_show_sets(tournament_name='hidden-bosses-4-0',
                                                  event='wii-u-doubles')
-        self.assertTrue(len(result) == 76)
+        self.assertTrue(len(result) == 57)
 
     def test_tournament_show_players(self):
         with self.assertRaises(ValidationError) as context:


### PR DESCRIPTION
…_show_sets would not

Route now correctly ignores sets that were not played (either it was a
“by” round, a “preview” bracket or it was “WF” in pools bracket (where
the match was not actually played))