### PR TITLE
add additional endpoints to filter requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# notifier
+
+This branch includes a "notifier" for use with an ongoing smash.gg bracket. 
+To use, simply run the notifier.py and follow the directions displayed.
+The format for tournaments/events is as follows:
+https://smash.gg/tournament/genesis-5/events/melee-singles
+
+The tournament name is what follows /tournament/, and the event name is what follows /events/.
+
 # pysmash
 
 [![Build Status](http://drone.peterballz.com/api/badges/PeterCat12/pysmash/status.svg)](http://drone.peterballz.com/PeterCat12/pysmash)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ smash = pysmash.SmashGG()
 
   # Shows a complete list of sets given tournament and event names
   # By default, this method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
-  # potentially fed into another bracket.); these sets can be viewed by passing False for filter_unplayed
+  # potentially fed into another bracket.); these sets can be viewed by passing False for filter_current.
+  # Additionally, it is possible to view sets that are not yet ready to be played by passing False for filter_future
+  # If one wants to exclude already completed sets, likely for the use of an application that hooks into brackets real-time
+  # False can be passed for filter_completed
   sets = smash.tournament_show_sets('hidden-bosses-4-0', 'wii-u-singles')
   print(sets) # note: result might be VERY large for larger tournaments.
 
@@ -87,7 +90,10 @@ smash = pysmash.SmashGG()
 
   # Shows player info and a list of every set that player competed in given tournament and event names
   # By default, this method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
-  # potentially fed into another bracket.); these sets can be viewed by passing False for filter_unplayed
+  # potentially fed into another bracket.); these sets can be viewed by passing False for filter_current.
+  # Additionally, it is possible to view sets that are not yet ready to be played by passing False for filter_future
+  # If one wants to exclude already completed sets, likely for the use of an application that hooks into brackets real-time
+  # False can be passed for filter_completed
   player_sets = smash.tournament_show_player_sets('hidden-bosses-4-0', 'DOM', 'wii-u-singles')
   print(player_sets)
 
@@ -124,9 +130,12 @@ import pysmash
 
   # show sets for a bracket
   # By default, this method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
-  # potentially fed into another bracket.); these sets can be viewed by passing False for filter unplayed
+  # potentially fed into another bracket.); these sets can be viewed by passing False for filter_current.
+  # Additionally, it is possible to view sets that are not yet ready to be played by passing False for filter_future
+  # If one wants to exclude already completed sets, likely for the use of an application that hooks into brackets real-time
+  # False can be passed for filter_completed
   brackets = smash.tournament_show_event_brackets('hidden-bosses-4-0', 'wii-u-singles')
-  sets =  self.smash.bracket_show_sets(brackets['bracket_ids'][0]) # <- bracket_id
+  sets = self.smash.bracket_show_sets(brackets['bracket_ids'][0]) # <- bracket_id
   # sets = self.smash.bracket_show_sets(225024) # <- if you know the id before hand
   print(sets)
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-# notifier
-
-This branch includes a "notifier" for use with an ongoing smash.gg bracket. 
-To use, simply run the notifier.py and follow the directions displayed.
-The format for tournaments/events is as follows:
-https://smash.gg/tournament/genesis-5/events/melee-singles
-
-The tournament name is what follows /tournament/, and the event name is what follows /events/.
-
 # pysmash
 
 [![Build Status](http://drone.peterballz.com/api/badges/PeterCat12/pysmash/status.svg)](http://drone.peterballz.com/PeterCat12/pysmash)

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ smash = pysmash.SmashGG()
   print(events)
 
   # Shows a complete list of sets given tournament and event names
-  # This method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
-  # potentially fed into another bracket.)
+  # By default, this method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
+  # potentially fed into another bracket.); these sets can be viewed by passing False for filter_unplayed
   sets = smash.tournament_show_sets('hidden-bosses-4-0', 'wii-u-singles')
   print(sets) # note: result might be VERY large for larger tournaments.
 
@@ -86,8 +86,8 @@ smash = pysmash.SmashGG()
   print(brackets)
 
   # Shows player info and a list of every set that player competed in given tournament and event names
-  # This method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
-  # potentially fed into another bracket.)
+  # By default, this method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
+  # potentially fed into another bracket.); these sets can be viewed by passing False for filter_unplayed
   player_sets = smash.tournament_show_player_sets('hidden-bosses-4-0', 'DOM', 'wii-u-singles')
   print(player_sets)
 
@@ -122,9 +122,9 @@ import pysmash
   # bracket_players = smash.bracket_show_players(224997) # <- if you know the id before hand
   print(bracket_players)
 
-  # show played sets for a bracket
-  # This method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
-  # potentially fed into another bracket.)
+  # show sets for a bracket
+  # By default, this method ignores sets without a recorded score (Smash.gg "oddity". Either the set was not played or the set
+  # potentially fed into another bracket.); these sets can be viewed by passing False for filter unplayed
   brackets = smash.tournament_show_event_brackets('hidden-bosses-4-0', 'wii-u-singles')
   sets =  self.smash.bracket_show_sets(brackets['bracket_ids'][0]) # <- bracket_id
   # sets = self.smash.bracket_show_sets(225024) # <- if you know the id before hand

--- a/pysmash/brackets.py
+++ b/pysmash/brackets.py
@@ -132,8 +132,14 @@ def _get_set_from_bracket(bracket_set, is_final_bracket, filter_unplayed=True):
 
     # winner's id of `None` or loser's id of `None` means the set was not played
     # if not filtering, will return winner and loser id of 'None'
-    if filter_unplayed and (bracket_set['winnerId'] is None or bracket_set['loserId'] is None):
-        return None, False
+    if filter_unplayed:
+        if bracket_set['winnerId'] is None or bracket_set['loserId'] is None:
+            return None, False
+
+    #we want unplayed sets, not sets that will never be played (that feed into other brackets without being played)
+    elif filter_unplayed is False:
+        if bracket_set['unreachable'] is True:
+            return None,False
 
     _set = {
         'id': str(bracket_set['id']),  # make all IDS ints?

--- a/pysmash/smashgg.py
+++ b/pysmash/smashgg.py
@@ -40,10 +40,10 @@ class SmashGG(object):
         """Show a list of events belonging to a tournment"""
         return tournaments.show_events(tournament_name)
 
-    def tournament_show_sets(self, tournament_name, event='', params=[]):
+    def tournament_show_sets(self, tournament_name, event='', params=[], filter_unplayed=True):
         """Shows a complete list of sets given a tournament and event names"""
         event = self._validate_event_name(event)
-        return tournaments.show_sets(tournament_name, event, params)
+        return tournaments.show_sets(tournament_name, event, params, filter_unplayed)
 
     def tournament_show_players(self, tournament_name, event='', tournament_params=[]):
         """Shows a complete list of players/entrants given a tournament and event name"""
@@ -55,9 +55,9 @@ class SmashGG(object):
         event = self._validate_event_name(event)
         return tournaments.event_brackets(tournament_name, event, filter_response)
 
-    def tournament_show_player_sets(self, tournament_name, player_tag, event=''):
+    def tournament_show_player_sets(self, tournament_name, player_tag, event='', filter_unplayed=True):
         event = self._validate_event_name(event)
-        return tournaments.show_player_sets(tournament_name, event, player_tag)
+        return tournaments.show_player_sets(tournament_name, event, player_tag, filter_unplayed)
 
     def tournament_show_head_to_head(self, tournament_name, player1_tag, player2_tag, event=''):
         event = self._validate_event_name(event)
@@ -68,9 +68,9 @@ class SmashGG(object):
         """Shows a list of players given a bracket id"""
         return brackets.players(bracket_id, filter_response)
 
-    def bracket_show_sets(self, bracket_id, filter_response=True):
+    def bracket_show_sets(self, bracket_id, filter_response=True, filter_unplayed=True):
         """Shows a list of sets given a bracket id"""
-        return brackets.sets(bracket_id, filter_response)
+        return brackets.sets(bracket_id, filter_response, filter_unplayed)
 
     def _validate_event_name(self, event):
         if event == '' and self.event == '':

--- a/pysmash/smashgg.py
+++ b/pysmash/smashgg.py
@@ -40,10 +40,10 @@ class SmashGG(object):
         """Show a list of events belonging to a tournment"""
         return tournaments.show_events(tournament_name)
 
-    def tournament_show_sets(self, tournament_name, event='', params=[], filter_unplayed=True):
+    def tournament_show_sets(self, tournament_name, event='', params=[], filter_completed=False, filter_current=True, filter_future=True):
         """Shows a complete list of sets given a tournament and event names"""
         event = self._validate_event_name(event)
-        return tournaments.show_sets(tournament_name, event, params, filter_unplayed)
+        return tournaments.show_sets(tournament_name, event, params, filter_completed, filter_current, filter_future)
 
     def tournament_show_players(self, tournament_name, event='', tournament_params=[]):
         """Shows a complete list of players/entrants given a tournament and event name"""
@@ -55,9 +55,9 @@ class SmashGG(object):
         event = self._validate_event_name(event)
         return tournaments.event_brackets(tournament_name, event, filter_response)
 
-    def tournament_show_player_sets(self, tournament_name, player_tag, event='', filter_unplayed=True):
+    def tournament_show_player_sets(self, tournament_name, player_tag, event='', filter_completed=False, filter_current=True, filter_future=True):
         event = self._validate_event_name(event)
-        return tournaments.show_player_sets(tournament_name, event, player_tag, filter_unplayed)
+        return tournaments.show_player_sets(tournament_name, event, player_tag, filter_completed, filter_current, filter_future)
 
     def tournament_show_head_to_head(self, tournament_name, player1_tag, player2_tag, event=''):
         event = self._validate_event_name(event)
@@ -68,9 +68,9 @@ class SmashGG(object):
         """Shows a list of players given a bracket id"""
         return brackets.players(bracket_id, filter_response)
 
-    def bracket_show_sets(self, bracket_id, filter_response=True, filter_unplayed=True):
+    def bracket_show_sets(self, bracket_id, filter_response=True, filter_completed=False, filter_current=True, filter_future=True):
         """Shows a list of sets given a bracket id"""
-        return brackets.sets(bracket_id, filter_response, filter_unplayed)
+        return brackets.sets(bracket_id, filter_response, filter_completed, filter_current, filter_future)
 
     def _validate_event_name(self, event):
         if event == '' and self.event == '':

--- a/pysmash/tournaments.py
+++ b/pysmash/tournaments.py
@@ -38,13 +38,13 @@ def show_with_brackets(tournament_name, event, tournament_params=[], ):
     return utils.merge_two_dicts(tournament, brackets)
 
 
-def show_sets(tournament_name, event, tournament_params=[]):
+def show_sets(tournament_name, event, tournament_params=[], filter_unplayed = True):
     """Returns all sets from a tournament"""
     tournament = show_with_brackets(tournament_name, event, tournament_params)
 
     results = []
     for bracket_id in tournament['bracket_ids']:
-        bracket_sets = brackets.sets(bracket_id)
+        bracket_sets = brackets.sets(bracket_id, True, filter_unplayed)
         for _set in bracket_sets:
             if len(_set) > 0:
                 results.append(_set)
@@ -64,7 +64,7 @@ def show_players(tournament_name, event_name, tournament_params=[]):
     return list({v['tag']: v for v in results}.values())
 
 
-def show_player_sets(tournament_name, event, player_tag):
+def show_player_sets(tournament_name, event, player_tag, filter_unplayed=True):
     """Returns all players from a tournament"""
     tournament = show_with_brackets(tournament_name, event)
 
@@ -72,7 +72,7 @@ def show_player_sets(tournament_name, event, player_tag):
     bracket_sets = []
 
     for bracket_id in tournament['bracket_ids']:
-        player_sets = brackets.sets_played_by_player(bracket_id, player_tag)
+        player_sets = brackets.sets_played_by_player(bracket_id, player_tag, filter_unplayed)
         if len(player_sets) == 0:
             continue
 

--- a/pysmash/tournaments.py
+++ b/pysmash/tournaments.py
@@ -38,13 +38,13 @@ def show_with_brackets(tournament_name, event, tournament_params=[], ):
     return utils.merge_two_dicts(tournament, brackets)
 
 
-def show_sets(tournament_name, event, tournament_params=[], filter_unplayed = True):
+def show_sets(tournament_name, event, tournament_params=[], filter_completed=False, filter_current=True, filter_future=True):
     """Returns all sets from a tournament"""
     tournament = show_with_brackets(tournament_name, event, tournament_params)
 
     results = []
     for bracket_id in tournament['bracket_ids']:
-        bracket_sets = brackets.sets(bracket_id, True, filter_unplayed)
+        bracket_sets = brackets.sets(bracket_id, True, filter_completed, filter_current, filter_future)
         for _set in bracket_sets:
             if len(_set) > 0:
                 results.append(_set)
@@ -64,7 +64,7 @@ def show_players(tournament_name, event_name, tournament_params=[]):
     return list({v['tag']: v for v in results}.values())
 
 
-def show_player_sets(tournament_name, event, player_tag, filter_unplayed=True):
+def show_player_sets(tournament_name, event, player_tag, filter_completed=False, filter_current=True, filter_future=True):
     """Returns all players from a tournament"""
     tournament = show_with_brackets(tournament_name, event)
 
@@ -72,7 +72,7 @@ def show_player_sets(tournament_name, event, player_tag, filter_unplayed=True):
     bracket_sets = []
 
     for bracket_id in tournament['bracket_ids']:
-        player_sets = brackets.sets_played_by_player(bracket_id, player_tag, filter_unplayed)
+        player_sets = brackets.sets_played_by_player(bracket_id, player_tag, filter_completed, filter_current, filter_future)
         if len(player_sets) == 0:
             continue
 


### PR DESCRIPTION
Currently, the only allowed behavior when filtering sets is to discard those that have been yet to be played. With this update, there is a value similar to filter_request called filter_unplayed that can be passed. If methods that filter sets are called with filter_unplayed as false, then the unplayed sets will be included in the results. This leaves current behavior unchanged, as the default value for filter_unplayed is true. This change is helpful for applications that may need to access smash.gg brackets that are in progress.