### PR TITLE
Tournaments.py doesn't currently take into account multiple players with the same tag

### DIFF
--- a/pysmash/brackets.py
+++ b/pysmash/brackets.py
@@ -171,6 +171,7 @@ def _get_player_from_entrant(entrant):
 
     return {
         'entrant_id': entrant['id'],
+        'player_id': player_id,
         'tag': player_dict['gamerTag'],
         'fname': fname,
         'lname': lname,

--- a/pysmash/tournaments.py
+++ b/pysmash/tournaments.py
@@ -61,7 +61,7 @@ def show_players(tournament_name, event_name, tournament_params=[]):
         bracket_players = brackets.players(bracket_id)
         for player in bracket_players:
             results.append(player)
-    return list({v['tag']: v for v in results}.values())
+    return list({v['player_id']: v for v in results}.values())
 
 
 def show_player_sets(tournament_name, event, player_tag):


### PR DESCRIPTION
In your "show_players" function, you return a list of values for all appended players, but you filter it based off of 'tag'. On smash.gg the same tag can appear more than once, so in this case it only lists the most recent appearance of that tag and completely overwrites any player info that shares that same tag. 

player_id appears to be the site-wide representation of unique players on smash.gg, so I've changed the players function in brackets.py to also provide player_id and changed tournaments.py to now go off of player_id. After testing it now lists every player even if they have matching tags (tested it with evo japan 2018). 

I haven't made changes to any other functions since these were the only ones that were affecting my code, I think your head_to_head stuff also goes off player_tags so those may also need to be modified.
